### PR TITLE
[#94] Fix captcha resolved callback reassignment

### DIFF
--- a/src/app/security/components/registration/registration.component.ts
+++ b/src/app/security/components/registration/registration.component.ts
@@ -96,10 +96,11 @@ export class RegistrationComponent implements OnInit {
 
       this.captchaRef.execute();
 
-      const callback = this.captchaResolved;
+      const resolvedCallback = this.captchaResolved;
       this.captchaResolved = function(captchaResponse: string) {
-        callback.call(this, captchaResponse);
+        resolvedCallback.call(this, captchaResponse);
         resolve(captchaResponse);
+        this.captchaResolved = resolvedCallback;
       };
     });
   }


### PR DESCRIPTION
Added a line that restores callback back to its original state after a
promise is resolved. That way several consecutive captcha calls do not
create nested resolve calls. Also renamed callback variable to make it
more verbose.